### PR TITLE
Add compile support to llama3 70B LoRA/full-finetune on multi-gpu

### DIFF
--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -74,7 +74,6 @@ resume_from_checkpoint: False
 # Fine-tuning arguments
 batch_size: 2
 epochs: 3
-compile: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -74,6 +74,7 @@ resume_from_checkpoint: False
 # Fine-tuning arguments
 batch_size: 2
 epochs: 3
+compile: False
 
 optimizer:
   _component_: torch.optim.AdamW

--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -87,6 +87,7 @@ loss:
   _component_: torch.nn.CrossEntropyLoss
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
+compile: False
 
 
 # Training env

--- a/recipes/configs/llama3/70B_full.yaml
+++ b/recipes/configs/llama3/70B_full.yaml
@@ -98,6 +98,9 @@ enable_activation_checkpointing: True
 memory_efficient_fsdp_wrap: True
 fsdp_cpu_offload: True
 
+fsdp:  # FSDP2
+  cpu_offload: True
+
 # Reduced precision
 dtype: bf16
 

--- a/recipes/configs/llama3/70B_lora.yaml
+++ b/recipes/configs/llama3/70B_lora.yaml
@@ -85,6 +85,7 @@ loss:
 epochs: 1
 max_steps_per_epoch: null
 gradient_accumulation_steps: 1
+compile: False
 
 # Logging
 output_dir: /tmp/lora_finetune_output

--- a/recipes/dev/full_finetune_fsdp2.py
+++ b/recipes/dev/full_finetune_fsdp2.py
@@ -335,6 +335,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         if compile_model:
             log.info("Compiling model with torch.compile...")
             backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+            torch._dynamo.config.inline_inbuilt_nn_modules = True
             model.compile(backend=backend)
     
         if self._is_rank_zero:

--- a/recipes/dev/full_finetune_fsdp2.py
+++ b/recipes/dev/full_finetune_fsdp2.py
@@ -6,9 +6,10 @@
 
 import sys
 import time
+import os
 
 from functools import partial
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 from warnings import warn
 
 import torch
@@ -16,20 +17,16 @@ from omegaconf import DictConfig, ListConfig
 
 from torch import nn
 from torch.distributed import init_process_group
-from torch.distributed.fsdp import (
-    CPUOffload,
-    FullOptimStateDictConfig,
-    FullStateDictConfig,
-    FullyShardedDataParallel as FSDP,
-    StateDictType,
-)
 from torch.optim import Optimizer
 from torch.utils.data import DataLoader, DistributedSampler
 
 from torchtune import config, modules, utils
 from torchtune.datasets import ConcatDataset
 from torchtune.recipe_interfaces import FTRecipeInterface
-from torchtune.utils.activations import apply_selective_activation_checkpointing
+from torch.distributed._composable.fsdp import fully_shard
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    CheckpointWrapper,
+)
 
 from tqdm import tqdm
 
@@ -203,6 +200,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
 
         ckpt_dict = self.load_checkpoint(cfg.checkpointer)
 
+        self._model_compile = cfg.compile
         # ``_setup_model`` handles initialization and loading the state dict. This method
         # should be called before ``_setup_optimizer`` since transforming the optimizer
         # state dict requires the model
@@ -210,10 +208,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             cfg_model=cfg.model,
             enable_activation_checkpointing=cfg.enable_activation_checkpointing,
             memory_efficient_fsdp_wrap=cfg.get("memory_efficient_fsdp_wrap", False),
-            fsdp_cpu_offload=cfg.get("fsdp_cpu_offload", False),
             model_state_dict=ckpt_dict[utils.MODEL_KEY],
-            ac_mode=cfg.get("ac_mode", None),
-            ac_option=cfg.get("ac_option", None),
+            cfg_fsdp=cfg.fsdp if hasattr(cfg, "fsdp") else None,
+            compile_model=self._model_compile,
         )
 
         self._tokenizer = config.instantiate(cfg.tokenizer)
@@ -259,10 +256,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         cfg_model: DictConfig,
         enable_activation_checkpointing: bool,
         memory_efficient_fsdp_wrap: bool,
-        fsdp_cpu_offload: bool,
         model_state_dict: Dict[str, Any],
-        ac_mode: Optional[str] = None,
-        ac_option: Optional[int] = None,
+        cfg_fsdp: Optional[Union[DictConfig, None]] = None,
+        compile_model: bool = False,
     ) -> nn.Module:
         """
         Model initialization has some important considerations:
@@ -278,82 +274,68 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         """
         if self._is_rank_zero:
             log.info("FSDP is enabled. Instantiating Model on CPU for Rank 0 ...")
-            init_start = time.perf_counter()
+            # init_start = time.perf_counter()
 
-            with utils.set_default_dtype(self._dtype):
-                model = config.instantiate(cfg_model)
-
-            log.info(
-                f"Model instantiation took {time.perf_counter() - init_start:.2f} secs"
-            )
-
-            # Load both the model weights. This should happen only on Rank 0
-            model.load_state_dict(model_state_dict)
-
-        else:
-            # For non-zero ranks, load the model on meta device
-            with utils.set_default_dtype(self._dtype), torch.device("meta"):
-                model = config.instantiate(cfg_model)
+        with utils.set_default_dtype(self._dtype), torch.device("meta"):
+            model = config.instantiate(cfg_model)
 
         if self._dtype == torch.bfloat16:
             model = model.to(torch.bfloat16)
 
-        # We currently have two versions of activation checkpointing in this recipe
-        # for testing and BC purposes. ``enable_activation_checkpointing`` controls
-        # the older version of AC and this behavior is unchanged
-        # ac_mode and ac_option together control selective AC. This is only enabled
-        # when these are set AND ``enable_activation_checkpointing`` is set to False
-        # We'll clean this up as soon as testing of AC is complete
-        ac_mode = ac_mode
-        ac_option = ac_option
-
-        if (not enable_activation_checkpointing) and (ac_mode is not None):
-            apply_selective_activation_checkpointing(
-                model,
-                ac_mode,
-                ac_option,
-            )
-        
-        if self._is_rank_zero:
-            print(f"before: model: {model}")
-
-        # Wrap the model with FSDP. This will ensure that the model is sharded
-        # across all available GPUs.
-        model = FSDP(
-            module=model,
-            auto_wrap_policy=utils.get_full_finetune_fsdp_wrap_policy(
-                memory_efficient_fsdp_wrap=memory_efficient_fsdp_wrap,
-                modules_to_wrap={modules.TransformerDecoderLayer},
-            ),
-            cpu_offload=CPUOffload(offload_params=fsdp_cpu_offload),
-            sharding_strategy=torch.distributed.fsdp.ShardingStrategy.FULL_SHARD,
-            device_id=self._device,
-            # this recipe does not currently support mixed precision training
-            mixed_precision=None,
-            # Ensure we broadcast params and buffers from rank 0
-            sync_module_states=True,
-            # Initialize empty modules on all non-zero ranks
-            param_init_fn=(
-                lambda module: module.to_empty(
-                    device=torch.device("cuda"), recurse=False
-                )
-                if not self._is_rank_zero
-                else None
-            ),
-        )
+        # # Load both the model weights. This should happen only on Rank 0
+        # model.load_state_dict(model_state_dict)
 
         if self._is_rank_zero:
-            print(f"after: model: {model}")
+            print(f"self._dtype: {self._dtype}")
 
-        # Ensure no params and buffers are on meta device
-        utils.validate_no_params_on_meta_device(model)
-
-        # original activation checkpointing (full) - flip the condition above
-        if enable_activation_checkpointing and ac_mode is None:
+        if enable_activation_checkpointing:
             utils.set_activation_checkpointing(
                 model, auto_wrap_policy={modules.TransformerDecoderLayer}
             )
 
+        if self._is_rank_zero:
+            print(f"before: model: {model}")
+
+        fsdp_kwargs = {}
+        if cfg_fsdp and cfg_fsdp.cpu_offload:
+            from torch.distributed._composable.fsdp import CPUOffloadPolicy
+
+            fsdp_kwargs["offload_policy"] = CPUOffloadPolicy()
+        # iterating from lowerer modules to higher
+        # eg grouping lora adapters before transformer block
+        for m_name, m in reversed(list(model.named_modules())):
+            if memory_efficient_fsdp_wrap:
+                if isinstance(m, nn.Embedding):
+                    fully_shard(m, **fsdp_kwargs)
+            # TransformerDecoderLayer is wrapped by CheckpointWrapper
+            # when enable_activation_checkpointing
+            if enable_activation_checkpointing:
+                if isinstance(m, CheckpointWrapper):
+                    fully_shard(m, **fsdp_kwargs)
+            else:
+                if isinstance(m, modules.TransformerDecoderLayer):
+                    fully_shard(m, **fsdp_kwargs)
+
+        if memory_efficient_fsdp_wrap:
+            fully_shard(model.output, **fsdp_kwargs)
+
+        fully_shard(model, **fsdp_kwargs)
+
+        if self._is_rank_zero:
+            print(f"after: model: {model}")
+
+        device = torch.device("cuda", torch.cuda.current_device())
+        model.to_empty(device=device)
+
+        # Ensure no params and buffers are on meta device
+        utils.validate_no_params_on_meta_device(model)
+
+        # Compile model, if enabled.
+        if compile_model:
+            log.info("Compiling model with torch.compile...")
+            backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+            model.compile(backend=backend)
+    
         if self._is_rank_zero:
             memory_stats = utils.get_memory_stats(device=self._device)
             utils.log_memory_stats(memory_stats)

--- a/recipes/dev/lora_finetune_fsdp2.py
+++ b/recipes/dev/lora_finetune_fsdp2.py
@@ -366,6 +366,7 @@ class LoRAFinetuneRecipeDistributed(FTRecipeInterface):
         if compile_model:
             log.info("Compiling model with torch.compile...")
             backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
+            torch._dynamo.config.inline_inbuilt_nn_modules = True
             model.compile(backend=backend)
 
         if self._is_rank_zero:

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -341,7 +341,7 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 if not self._is_rank_zero
                 else None
             ),
-            use_orig_params=True,
+            use_orig_params=True if compile_model else False,
         )
 
         # Ensure no params and buffers are on meta device

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -342,9 +342,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             ),
         )
 
-        if self._is_rank_zero:
-            print(f"after: model: {model}")
-
         # Ensure no params and buffers are on meta device
         utils.validate_no_params_on_meta_device(model)
 
@@ -353,6 +350,9 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             utils.set_activation_checkpointing(
                 model, auto_wrap_policy={modules.TransformerDecoderLayer}
             )
+
+        if self._is_rank_zero:
+            print(f"after: model: {model}")
 
         if self._is_rank_zero:
             memory_stats = utils.get_memory_stats(device=self._device)

--- a/recipes/full_finetune_distributed.py
+++ b/recipes/full_finetune_distributed.py
@@ -6,7 +6,6 @@
 
 import sys
 import time
-import os
 
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
@@ -207,7 +206,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         # ``_setup_model`` handles initialization and loading the state dict. This method
         # should be called before ``_setup_optimizer`` since transforming the optimizer
         # state dict requires the model
-        self._model_compile = cfg.compile
         self._model = self._setup_model(
             cfg_model=cfg.model,
             enable_activation_checkpointing=cfg.enable_activation_checkpointing,
@@ -216,7 +214,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             model_state_dict=ckpt_dict[utils.MODEL_KEY],
             ac_mode=cfg.get("ac_mode", None),
             ac_option=cfg.get("ac_option", None),
-            compile_model=self._model_compile,
         )
 
         self._tokenizer = config.instantiate(cfg.tokenizer)
@@ -266,7 +263,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
         model_state_dict: Dict[str, Any],
         ac_mode: Optional[str] = None,
         ac_option: Optional[int] = None,
-        compile_model: bool = False,
     ) -> nn.Module:
         """
         Model initialization has some important considerations:
@@ -341,7 +337,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
                 if not self._is_rank_zero
                 else None
             ),
-            use_orig_params=True if compile_model else False,
         )
 
         # Ensure no params and buffers are on meta device
@@ -352,12 +347,6 @@ class FullFinetuneRecipeDistributed(FTRecipeInterface):
             utils.set_activation_checkpointing(
                 model, auto_wrap_policy={modules.TransformerDecoderLayer}
             )
-
-        # Compile model, if enabled.
-        if compile_model:
-            log.info("Compiling model with torch.compile...")
-            backend = os.environ.get("TORCH_COMPILE_BACKEND", "inductor")
-            model.compile(backend=backend)
 
         if self._is_rank_zero:
             memory_stats = utils.get_memory_stats(device=self._device)


### PR DESCRIPTION
Repro steps:
- `with-proxy tune download meta-llama/Meta-Llama-3-70B-Instruct --output-dir /tmp/Meta-Llama-3-70B-Instruct --hf-token <HF_TOKEN> --ignore-patterns "original/consolidated*"`
- `with-proxy tune run --nproc_per_node 8 recipes/dev/lora_finetune_fsdp2.py --config llama3/70B_lora compile=True`
----
#### Context
What is the purpose of this PR? Is it to
- [x] add a new feature
- [ ] fix a bug
- [ ] update tests and/or documentation
- [ ] other (please add here)

#### Changelog
This PR adds compile support to llama3 70B full-finetune on multi-gpu.

#### Test plan
Please make sure to do each of the following if applicable to your PR. (If you're not sure about any one of these just ask and we will happily help.)

- [ ] run pre-commit hooks and linters (make sure you've first installed via `pre-commit install`)
- [ ] add unit tests for any new functionality
- [ ] update docstrings for any new or updated methods or classes
- [ ] run unit tests via `pytest tests`
- [ ] run recipe tests via `pytest tests -m integration_test`
- [ ] manually run any new or modified recipes with sufficient proof of correctness
	- [ ] include relevant commands and any other artifacts in this summary (pastes of loss curves, eval results, etc.)
